### PR TITLE
Define HSTX pins on Adafruit boards with HSTX or DVI connectors

### DIFF
--- a/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
+++ b/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
@@ -39,4 +39,14 @@
 #define RP2350_PSRAM_CS         (8u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
+// DVI connector
+#define PIN_CKN (15u)
+#define PIN_CKP (14u)
+#define PIN_D0N (19u)
+#define PIN_D0P (18u)
+#define PIN_D1N (17u)
+#define PIN_D1P (16u)
+#define PIN_D2N (13u)
+#define PIN_D2P (12u)
+
 #include "../generic/common.h"

--- a/variants/adafruit_fruitjam/pins_arduino.h
+++ b/variants/adafruit_fruitjam/pins_arduino.h
@@ -78,4 +78,14 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
+// DVI connector
+#define PIN_CKN (12u)
+#define PIN_CKP (13u)
+#define PIN_D0N (14u)
+#define PIN_D0P (15u)
+#define PIN_D1N (16u)
+#define PIN_D1P (17u)
+#define PIN_D2N (18u)
+#define PIN_D2P (19u)
+
 #include "../generic/common.h"

--- a/variants/adafruit_metro_rp2350/pins_arduino.h
+++ b/variants/adafruit_metro_rp2350/pins_arduino.h
@@ -68,4 +68,15 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
+// DVI connector
+#define PIN_CKN (15u)
+#define PIN_CKP (14u)
+#define PIN_D0N (19u)
+#define PIN_D0P (18u)
+#define PIN_D1N (17u)
+#define PIN_D1P (16u)
+#define PIN_D2N (13u)
+#define PIN_D2P (12u)
+
+
 #include "../generic/common.h"


### PR DESCRIPTION
This follows the mold established for the feather rp2040 dvi.

I didn't test these yet, just copied em from the prettypins. Transcription errors likely.

I'll make Adafruit_dvhstx use these defines to create a "this board" pinout where possible.